### PR TITLE
Rollbar initialization only if config is not empty

### DIFF
--- a/Plugin/InitPlugin.php
+++ b/Plugin/InitPlugin.php
@@ -4,12 +4,14 @@ namespace Rollbar\Magento2\Plugin;
 
 class InitPlugin
 {
-	public function beforeLaunch(\Magento\Framework\AppInterface $subject)
-	{
-		$objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-		$deploymentConfig = $objectManager->get(\Magento\Framework\App\DeploymentConfig::class); 
-		$rollbarConfig = $deploymentConfig->get('rollbar');
+    public function beforeLaunch(\Magento\Framework\AppInterface $subject)
+    {
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        $deploymentConfig = $objectManager->get(\Magento\Framework\App\DeploymentConfig::class);
+        $rollbarConfig = $deploymentConfig->get('rollbar');
 
-		\Rollbar\Rollbar::init($rollbarConfig);
-	}
+        if($rollbarConfig) {
+            \Rollbar\Rollbar::init($rollbarConfig);
+        }
+    }
 }


### PR DESCRIPTION
Hi,

That small change can allow our team to run your extension on development environments, where we do not want to enter any Rollbar credentials. 

Thanks :)